### PR TITLE
Fixing first commit on new branch issue on github action

### DIFF
--- a/.github/workflows/update_generated_code_and_compile.yml
+++ b/.github/workflows/update_generated_code_and_compile.yml
@@ -25,17 +25,27 @@ jobs:
         # Checkout as many commits as needed for the diff
         fetch-depth: 0 # this gets all commits
     - shell: pwsh
-      id: check_file_changed
+      id: check_file_changed 
       run: |
-        # Diff HEAD with the last commit pushed
-        $diff = git diff --name-only ${{github.event.before}} ${{github.event.after}}
+        # Using this to protect against the first commit of a new branch on this weird github environment
+        $bad_hash = "0000000000000000000000000000000000000000"
+        if("${{github.event.before}}" -ne $bad_hash)
+        {
+          # Diff HEAD with the last commit pushed
+          $diff = git diff --name-only ${{github.event.before}} ${{github.event.after}}
 
-        # Check if a file under dbc/ or with the .dbc extension has changed (added, modified, deleted)
-        $SourceDiff = $diff | Where-Object { $_ -match '^dbc/' -or $_ -match '.dbc$' }
-        $HasDiff = $SourceDiff.Length -gt 0
+          # Check if a file under dbc/ or with the .dbc extension has changed (added, modified, deleted)
+          $SourceDiff = $diff | Where-Object { $_ -match '^dbc/' -or $_ -match '.dbc$' }
+          $HasDiff = $SourceDiff.Length -gt 0
 
-        # Set the output named "dbc_changed"
-        Write-Host "::set-output name=dbc_changed::$HasDiff"
+          # Set the output named "dbc_changed"
+          Write-Host "::set-output name=dbc_changed::$HasDiff"
+        }
+        # if this is the first commit trigger the build anyway. it's only one wasted run. 
+        if("${{github.event.before}}" -eq "0000000000000000000000000000000000000000")
+        {
+          Write-Host "::set-output name=dbc_changed::$true"
+        }
  generate_c_interface:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest

--- a/docs/vehicle_networks.md
+++ b/docs/vehicle_networks.md
@@ -39,7 +39,7 @@ An off the shelf data acquisition setup with no network would look something lik
 ![image](high_level_view_w_daq.png)<br>
 All wires tie into a central point. Seems simple enough. However, you have to pick that DAQ carefully and that DAQ device measures what it measures, nothing more. If you want to add more signals, you have to disconnect something. If you find a sensor that looks great but is incompatible, you have to do signal adaptation. Or you have buy another DAQ. Additionally wire runs become cumbersome and faulty. Additionally, without a truly expensive hardware, you have no means of looking at what's happening live, on OR off the car. 
 
-Taking a hypothetical different approach, you'd have something like this (I didn't draw the can lines, I got lazy):
+Taking a hypothetical different approach, you'd have something like this (I didn't draw the can lines, I got lazy):<br>
 ![image](high_level_view_w_can.png)
 
 Consider the blue nodes as the items you intend to run full time. Sensor signals run to node they are closest to and get dropped on the network at their specified sample rate. A logger, shown in yellow can be added to the network can be attached to the bus and log the full traffic. The two red development nodes may include specialized sesnors just for development logging and tuning. When the time comes, the sensors and the nodes are removed and unplugged from the vehicle.


### PR DESCRIPTION
Our national nightmare is over but it will haunt me to my grave. 
Why is powershell so weird and why did the guy that wrote the action use powershell. 

This PR fixes the issue related to the first push of a new branch not building the dbc headers.
In github actions the env variable ```github.event.before``` resolves to all zeros on the first push of a branch. 
In the diff check to review of the .dbc file changed, we are unable to pull a diff because the git hash is invalid.

The conditional check will register true if this is the first commit of a branch no matter what. The .dbc header and c file will be built but if there is no changes, they simply will not commit as there are no changes and the system is not forced to do a blank commit.  (basically no ```--allow-empty``` option in the subsequent steps)

Hopefully this increases usability and resolves any issues regarding .dbc updates. Push, Pull, and move on

